### PR TITLE
Prevent download failures due to "/" in filename

### DIFF
--- a/nptel_pdf_web_course_downloader.py
+++ b/nptel_pdf_web_course_downloader.py
@@ -48,6 +48,7 @@ if __name__ == '__main__':
 			downloadUrl = 'http://nptel.ac.in/courses/' + downloadUrlPart[ downloadUrlPart.find('/') + 1 : ]
 			downloadUrl = "%20".join(downloadUrl.split(' '))
 			saveFileName = fileNumberName + topicList[fileNumber-1]
+			saveFileName = saveFileName.replace("/", "")
 			try :	
 				urllib.request.urlretrieve( downloadUrl , saveFileName )
 				#print("Downloaded : " + saveFileName)


### PR DESCRIPTION
"/" is a forbidden character in UNIX filenames, which prevented download (eg.: "I/O" in filename). So the saveFileName is filtered to remove "/"